### PR TITLE
Add libdl to CMake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Deprecated
 
+## [1.0.0-rc.2] - 2023-11-06
+
+### Fixed
+
+- Added link to libdl
+
 ## [1.0.0-rc.1] - 2023-11-01
 
 ### Added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,10 @@ target_link_libraries(
   Fortran_UDUNITS2
   udunits::udunits EXPAT::EXPAT
 )
+# We also need to link to dl if CMAKE_DL_LIBS is set
+if (CMAKE_DL_LIBS)
+  target_link_libraries(Fortran_UDUNITS2 ${CMAKE_DL_LIBS})
+endif ()
 
 # Install the library
 install(


### PR DESCRIPTION
Testing on discover found that we need to add libdl to the link line (at least with gfortran).

Following https://stackoverflow.com/questions/20131138/cmake-add-ldl-at-end-of-link-stage-of-add-library, we use a guard because some OS might not have it?